### PR TITLE
[BUG] Fix align_output error by explicitly importing whisperx.alignment 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04
+FROM nvidia/cuda:12.8.0-cudnn-runtime-ubuntu24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM nvidia/cuda:12.8.0-cudnn-runtime-ubuntu24.04
+FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-c"]
 WORKDIR /
 
-# System packages: Python 3.12, FFmpeg 6.1, utilities
+# System packages: Python 3.12, FFmpeg, utilities
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         python3 python3-pip python3-venv python3-dev \

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -1,5 +1,5 @@
-# ---------- PyTorch CUDA 12.6 wheels ----------
---extra-index-url https://download.pytorch.org/whl/cu126
+# ---------- PyTorch CUDA 12.8 wheels ----------
+--extra-index-url https://download.pytorch.org/whl/cu128
 torch~=2.8.0
 torchaudio~=2.8.0
 

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -1,5 +1,5 @@
-# ---------- PyTorch CUDA 12.8 wheels ----------
---extra-index-url https://download.pytorch.org/whl/cu128
+# ---------- PyTorch CUDA 12.6 wheels ----------
+--extra-index-url https://download.pytorch.org/whl/cu126
 torch~=2.8.0
 torchaudio~=2.8.0
 

--- a/src/predict.py
+++ b/src/predict.py
@@ -13,6 +13,7 @@ import math
 import os
 import shutil
 import whisperx
+import whisperx.alignment
 import tempfile
 import time
 import torch


### PR DESCRIPTION
whisperx v3.8.1 uses lazy imports, so submodules aren't available as attributes unless explicitly imported. This caused "module 'whisperx' has no attribute 'alignment'" when align_output was enabled. 